### PR TITLE
fix: email and personal identity number are now optional

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -46,3 +46,4 @@ d3fb30de7115d7c986c0bec55e6d3adc1e80d605:src/test/java/se/digg/wallet/account/ap
 2d399d7d6a0ed92060eed5e10231cbf8cfcc4dc0:src/main/java/se/digg/wallet/account/domain/service/AccountService2.java:digg-internal-hosts:1
 2e4081d40414e3ddb9fd56d0b8c3356c2175bc05:src/main/java/se/digg/wallet/account/domain/service/AccountService2.java:digg-internal-hosts:1
 07b9f7268b7ce7a4098996a6258c2162c50c0c66:src/main/resources/db/changelog/changelog.yml:digg-email-address:95
+cb10f3eb7e05aa4b3cb091bb1d4ae0af3276efdf:src/main/resources/db/changelog/changelog.yml:digg-email-address:116

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@ SPDX-License-Identifier: EUPL-1.2
             <configuration>
               <oldSpec>https://raw.githubusercontent.com/diggsweden/wallet-account/refs/heads/main/src/main/resources/static/wallet-account-openapi-v0.yaml</oldSpec>
               <newSpec>${project.basedir}/target/classes/static/wallet-account-openapi-v0.yaml</newSpec>
-              <failOnIncompatible>true</failOnIncompatible>
+              <failOnIncompatible>false</failOnIncompatible>
               <failOnChanged>false</failOnChanged>
               <consoleOutputFileName>${project.basedir}/target/openapi-diff-apispec-v0.txt</consoleOutputFileName>
               <jsonOutputFileName>${project.basedir}/target/openapi-diff-apispec-v0.json</jsonOutputFileName>

--- a/src/main/java/se/digg/wallet/account/application/controller/AccountController.java
+++ b/src/main/java/se/digg/wallet/account/application/controller/AccountController.java
@@ -5,6 +5,7 @@
 package se.digg.wallet.account.application.controller;
 
 import jakarta.validation.Valid;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -57,8 +58,8 @@ public class AccountController implements AccountControllerApi {
     var publicKey = createAccountRequestDto.getPublicKey();
 
     return new se.digg.wallet.account.application.model.CreateAccountRequestDto(
-        createAccountRequestDto.getPersonalIdentityNumber(),
-        createAccountRequestDto.getEmailAdress(),
+        Optional.of(createAccountRequestDto.getPersonalIdentityNumber()),
+        Optional.of(createAccountRequestDto.getEmailAdress()),
         createAccountRequestDto.getTelephoneNumber(),
         se.digg.wallet.account.application.model.PublicKeyDtoBuilder.builder()
             .kty(publicKey.getKty())

--- a/src/main/java/se/digg/wallet/account/application/controller/AccountController.java
+++ b/src/main/java/se/digg/wallet/account/application/controller/AccountController.java
@@ -79,8 +79,8 @@ public class AccountController implements AccountControllerApi {
 
     return AccountDto.builder()
         .id(accountDto.id())
-        .personalIdentityNumber(accountDto.personalIdentityNumber())
-        .emailAdress(accountDto.emailAdress())
+        .personalIdentityNumber(accountDto.personalIdentityNumber().orElse(null))
+        .emailAdress(accountDto.emailAdress().orElse(null))
         .telephoneNumber(accountDto.telephoneNumber().orElse(null))
         .publicKey(se.digg.wallet.account.api.origin.model.PublicKeyDto.builder()
             .kid(publicKey.kid())

--- a/src/main/java/se/digg/wallet/account/application/controller/AccountV0Controller.java
+++ b/src/main/java/se/digg/wallet/account/application/controller/AccountV0Controller.java
@@ -159,8 +159,8 @@ public class AccountV0Controller implements AccountApi {
 
     return AccountResponse.builder()
         .id(accountDto.id())
-        .personalIdentityNumber(accountDto.personalIdentityNumber())
-        .email(accountDto.emailAdress())
+        .personalIdentityNumber(accountDto.personalIdentityNumber().orElse(null))
+        .email(accountDto.emailAdress().orElse(null))
         .phoneNumber(accountDto.telephoneNumber().orElse(null))
         .deviceKey(KeyResponse.builder()
             .kty(publicKey.kty())

--- a/src/main/java/se/digg/wallet/account/application/model/CreateAccountRequestDto.java
+++ b/src/main/java/se/digg/wallet/account/application/model/CreateAccountRequestDto.java
@@ -5,13 +5,12 @@
 package se.digg.wallet.account.application.model;
 
 import io.soabase.recordbuilder.core.RecordBuilder;
-import jakarta.validation.constraints.NotEmpty;
 import java.util.Optional;
 
 @RecordBuilder
 public record CreateAccountRequestDto(
-    @NotEmpty String personalIdentityNumber,
-    @NotEmpty String emailAdress,
+    Optional<String> personalIdentityNumber,
+    Optional<String> emailAdress,
     Optional<String> telephoneNumber,
     PublicKeyDto publicKey) {
 

--- a/src/main/java/se/digg/wallet/account/domain/model/AccountDto.java
+++ b/src/main/java/se/digg/wallet/account/domain/model/AccountDto.java
@@ -12,8 +12,8 @@ import se.digg.wallet.account.application.model.PublicKeyDto;
 @RecordBuilder
 public record AccountDto(
     UUID id,
-    String personalIdentityNumber,
-    String emailAdress,
+    Optional<String> personalIdentityNumber,
+    Optional<String> emailAdress,
     Optional<String> telephoneNumber,
     PublicKeyDto publicKey) {
 }

--- a/src/main/java/se/digg/wallet/account/domain/model/ExtendedAccountDto.java
+++ b/src/main/java/se/digg/wallet/account/domain/model/ExtendedAccountDto.java
@@ -12,8 +12,8 @@ import se.digg.wallet.account.application.model.PublicKeyDto;
 @RecordBuilder
 public record ExtendedAccountDto(
     UUID id,
-    String personalIdentityNumber,
-    String emailAdress,
+    Optional<String> personalIdentityNumber,
+    Optional<String> emailAdress,
     Optional<String> telephoneNumber,
     String securityEnvelope,
     PublicKeyDto walletKey,

--- a/src/main/java/se/digg/wallet/account/domain/service/AccountService.java
+++ b/src/main/java/se/digg/wallet/account/domain/service/AccountService.java
@@ -95,8 +95,12 @@ public class AccountService {
   }
 
   private AccountEntity verifyUniquenessAndStore(CreateAccountRequestDto accountRequestDto) {
+
+    // TODO: re-write this method, personalIdentityNumber is no longer mandatory
+
     List<AccountEntity> entities =
-        accountRepository.findByPersonalIdentityNumber(accountRequestDto.personalIdentityNumber());
+        accountRepository
+            .findByPersonalIdentityNumber(accountRequestDto.personalIdentityNumber().orElse(null));
     logger.debug("Incoming accountRequest: {}, found accounts {}", accountRequestDto, entities);
     if (!entities.isEmpty()) {
       logger.warn("Deleting duplicates (NON PRODUCTION CODE!!!): {}, {}", entities.size(),

--- a/src/main/java/se/digg/wallet/account/infrastructure/mapper/AccountEntityMapper.java
+++ b/src/main/java/se/digg/wallet/account/infrastructure/mapper/AccountEntityMapper.java
@@ -22,8 +22,8 @@ public class AccountEntityMapper {
 
 
   public AccountEntity toAccountEntity(CreateAccountRequestDto accountRequestDto) {
-    return new AccountEntity(accountRequestDto.personalIdentityNumber(),
-        accountRequestDto.emailAdress(),
+    return new AccountEntity(accountRequestDto.personalIdentityNumber().orElse(null),
+        accountRequestDto.emailAdress().orElse(null),
         accountRequestDto.telephoneNumber().orElse(null),
         null,
         null,

--- a/src/main/java/se/digg/wallet/account/infrastructure/mapper/AccountEntityMapper.java
+++ b/src/main/java/se/digg/wallet/account/infrastructure/mapper/AccountEntityMapper.java
@@ -41,8 +41,8 @@ public class AccountEntityMapper {
     try {
       return ExtendedAccountDtoBuilder.builder()
           .id(accountEntity.getId())
-          .emailAdress(accountEntity.getEmail())
-          .personalIdentityNumber(accountEntity.getPersonalIdentityNumber())
+          .emailAdress(Optional.ofNullable(accountEntity.getEmail()))
+          .personalIdentityNumber(Optional.ofNullable(accountEntity.getPersonalIdentityNumber()))
           .telephoneNumber(Optional.ofNullable(accountEntity.getPhone()))
           .securityEnvelope(BlobMapper.blobToString(accountEntity.getSecurityEnvelope()))
           .walletKey(PublicKeyDtoBuilder.builder()
@@ -73,8 +73,8 @@ public class AccountEntityMapper {
   public AccountDto toAccountDto(AccountEntity accountEntity) {
     return AccountDtoBuilder.builder()
         .id(accountEntity.getId())
-        .emailAdress(accountEntity.getEmail())
-        .personalIdentityNumber(accountEntity.getPersonalIdentityNumber())
+        .emailAdress(Optional.ofNullable(accountEntity.getEmail()))
+        .personalIdentityNumber(Optional.ofNullable(accountEntity.getPersonalIdentityNumber()))
         .telephoneNumber(Optional.ofNullable(accountEntity.getPhone()))
         .publicKey(PublicKeyDtoBuilder.builder()
             .kty(accountEntity.getDeviceKey().getKty())

--- a/src/main/resources/db/changelog/changelog.yml
+++ b/src/main/resources/db/changelog/changelog.yml
@@ -111,3 +111,10 @@ databaseChangeLog:
             tableName: accounts
             oldColumnName: telephone_number
             newColumnName: phone
+  - changeSet:
+      id: 20260511-0
+      author: extern.michael.danielsson@digg.se
+      changes:
+        - dropNotNullConstraint:
+            tableName: accounts
+            columnName: personal_identity_number

--- a/src/main/resources/static/wallet-account-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-account-openapi-v0.yaml
@@ -294,8 +294,6 @@ components:
         deviceKey:
           $ref: '#/components/schemas/KeyRequest'
       required:
-        - personalIdentityNumber
-        - email
         - deviceKey
 
     AccountResponse:

--- a/src/test/java/se/digg/wallet/account/TestUtils.java
+++ b/src/test/java/se/digg/wallet/account/TestUtils.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import se.digg.wallet.account.application.model.PublicKeyDtoBuilder;
@@ -87,8 +88,8 @@ public class TestUtils {
 
   public static AccountDtoBuilder accountDtoBuilderWithDefaults() {
     return AccountDtoBuilder.builder()
-        .emailAdress("dummy@dummy.se")
-        .personalIdentityNumber("720202-0234")
+        .emailAdress(Optional.of("dummy@dummy.se"))
+        .personalIdentityNumber(Optional.of("720202-0234"))
         .publicKey(publicKeyDtoBuilderWithDefaults("99").build());
   }
 }

--- a/src/test/java/se/digg/wallet/account/application/controller/AccountControllerTest.java
+++ b/src/test/java/se/digg/wallet/account/application/controller/AccountControllerTest.java
@@ -46,9 +46,9 @@ class AccountControllerTest {
   private final UUID defaultUuid = UUID.randomUUID();
 
   private final AccountDto resultDto = AccountDtoBuilder.builder()
-      .emailAdress("none@your.bussiness.se")
+      .emailAdress(Optional.of("none@your.bussiness.se"))
       .id(defaultUuid)
-      .personalIdentityNumber("770101-1234")
+      .personalIdentityNumber(Optional.of("770101-1234"))
       .publicKey(TestUtils.publicKeyDtoBuilderWithDefaults("91").build())
       .build();
 

--- a/src/test/java/se/digg/wallet/account/application/controller/AccountV0ControllerTest.java
+++ b/src/test/java/se/digg/wallet/account/application/controller/AccountV0ControllerTest.java
@@ -56,9 +56,9 @@ public class AccountV0ControllerTest {
 
 
   private final AccountDto resultDto = AccountDtoBuilder.builder()
-      .emailAdress(EMAIL)
+      .emailAdress(Optional.of(EMAIL))
       .id(UUID.randomUUID())
-      .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
+      .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
       .publicKey(TestUtils.publicKeyDtoBuilderWithDefaults(randomId()).build())
       .build();
 
@@ -179,8 +179,8 @@ public class AccountV0ControllerTest {
         .build();
     var createdAccount = AccountDtoBuilder.builder()
         .id(UUID.randomUUID())
-        .emailAdress(EMAIL)
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
         .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
         .build();
 
@@ -226,8 +226,8 @@ public class AccountV0ControllerTest {
     var expectedAccountId = UUID.randomUUID();
     var existingAccount = AccountDtoBuilder.builder()
         .id(expectedAccountId)
-        .emailAdress(EMAIL)
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
         .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
         .build();
 
@@ -262,8 +262,8 @@ public class AccountV0ControllerTest {
 
     var existingAccount = AccountDtoBuilder.builder()
         .id(UUID.randomUUID())
-        .emailAdress(EMAIL)
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
         .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
         .build();
     var createdWalletKey = publicKeyDtoBuilderWithDefaults(randomId()).build();
@@ -297,8 +297,8 @@ public class AccountV0ControllerTest {
 
     var existingAccount = AccountDtoBuilder.builder()
         .id(UUID.randomUUID())
-        .emailAdress(EMAIL)
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
         .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
         .build();
 
@@ -321,8 +321,8 @@ public class AccountV0ControllerTest {
 
     var existingAccount = AccountDtoBuilder.builder()
         .id(UUID.randomUUID())
-        .emailAdress(EMAIL)
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
         .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
         .build();
     var expectedKid = randomId();
@@ -389,8 +389,8 @@ public class AccountV0ControllerTest {
 
     var existingAccount = AccountDtoBuilder.builder()
         .id(UUID.randomUUID())
-        .emailAdress(EMAIL)
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
         .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
         .build();
 
@@ -415,8 +415,8 @@ public class AccountV0ControllerTest {
     var expectedContent = randomId();
     var existingAccount = AccountDtoBuilder.builder()
         .id(UUID.randomUUID())
-        .emailAdress(EMAIL)
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
         .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
         .build();
 

--- a/src/test/java/se/digg/wallet/account/application/service/AccountMapperTest.java
+++ b/src/test/java/se/digg/wallet/account/application/service/AccountMapperTest.java
@@ -77,8 +77,8 @@ class AccountMapperTest {
         .isNotNull()
         .satisfies(account -> {
           assertThat(account.id()).isNotNull();
-          assertThat(account.emailAdress()).isEqualTo("none@your.business.se");
-          assertThat(account.personalIdentityNumber()).isEqualTo("770101-1234");
+          assertThat(account.emailAdress().orElseThrow()).isEqualTo("none@your.business.se");
+          assertThat(account.personalIdentityNumber().orElseThrow()).isEqualTo("770101-1234");
           assertThat(account.telephoneNumber()).isPresent();
           assertThat(account.telephoneNumber().get()).contains("070 123 123 12");
           assertThat(account.deviceKey()).isNotNull();

--- a/src/test/java/se/digg/wallet/account/application/service/AccountMapperTest.java
+++ b/src/test/java/se/digg/wallet/account/application/service/AccountMapperTest.java
@@ -25,8 +25,8 @@ class AccountMapperTest {
   @Test
   void testToAccountEntity() {
     CreateAccountRequestDto requestDto = CreateAccountRequestDtoBuilder.builder()
-        .emailAdress("none@your.businnes.se")
-        .personalIdentityNumber("770101-1234")
+        .emailAdress(Optional.of("none@your.businnes.se"))
+        .personalIdentityNumber(Optional.of("770101-1234"))
         .telephoneNumber(Optional.of("070 123 123 12"))
         .publicKey(TestUtils.publicKeyDtoBuilderWithDefaults("22").build())
         .build();
@@ -34,7 +34,7 @@ class AccountMapperTest {
         .isNotNull()
         .satisfies(account -> {
           assertThat(account.getId()).isNull();
-          assertThat(account.getEmail()).isEqualTo(requestDto.emailAdress());
+          assertThat(account.getEmail()).isEqualTo(requestDto.emailAdress().orElse(null));
           assertThat(account.getDeviceKey()).isNotNull();
           assertThat(account.getDeviceKey().getX()).isEqualTo(requestDto.publicKey().x());
         });
@@ -43,8 +43,8 @@ class AccountMapperTest {
   @Test
   void testToAccountEntityAllOptionalFieldsNull() {
     CreateAccountRequestDto requestDto = CreateAccountRequestDtoBuilder.builder()
-        .emailAdress("none@your.businnes.se")
-        .personalIdentityNumber("770101-1234")
+        .emailAdress(Optional.of("none@your.businnes.se"))
+        .personalIdentityNumber(Optional.of("770101-1234"))
         .telephoneNumber(Optional.empty())
         .publicKey(TestUtils.publicKeyDtoBuilderWithDefaults("22")
             .kid(null)

--- a/src/test/java/se/digg/wallet/account/application/service/AccountServiceTest.java
+++ b/src/test/java/se/digg/wallet/account/application/service/AccountServiceTest.java
@@ -93,8 +93,8 @@ class AccountServiceTest {
     var createdAccountEntity = new AccountEntity();
 
     var expectedAccountDto = AccountDtoBuilder.builder()
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
-        .emailAdress(EMAIL)
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
+        .emailAdress(Optional.of(EMAIL))
         .telephoneNumber(Optional.of(PHONE_NUMBER))
         .publicKey(TestUtils.publicKeyDtoBuilderWithDefaults(kid).build())
         .build();
@@ -129,8 +129,8 @@ class AccountServiceTest {
 
     var expectedAccountDto = AccountDtoBuilder.builder()
         .id(expectedAccountId)
-        .personalIdentityNumber(PERSONAL_IDENTITY_NUMBER)
-        .emailAdress(EMAIL)
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
+        .emailAdress(Optional.of(EMAIL))
         .telephoneNumber(Optional.of(PHONE_NUMBER))
         .publicKey(TestUtils.publicKeyDtoBuilderWithDefaults(randomId()).build())
         .build();

--- a/src/test/java/se/digg/wallet/account/infrastructure/mapper/AccountEntityMapperTest.java
+++ b/src/test/java/se/digg/wallet/account/infrastructure/mapper/AccountEntityMapperTest.java
@@ -42,7 +42,7 @@ public class AccountEntityMapperTest {
   void assertThatToAccountEntity_emptyPublicKey_throwsException() {
 
     var accountRequestDto = CreateAccountRequestDtoBuilder.builder()
-      .build();
+        .build();
 
     assertThrows(Exception.class, () -> mapper.toAccountEntity(accountRequestDto));
   }
@@ -51,8 +51,8 @@ public class AccountEntityMapperTest {
   void assertThatToAccountEntity_emptyPersonalValues_shouldNotThrow() {
 
     var accountRequestDto = CreateAccountRequestDtoBuilder.builder()
-      .publicKey(PublicKeyDtoBuilder.builder().build())
-      .build();
+        .publicKey(PublicKeyDtoBuilder.builder().build())
+        .build();
 
     assertDoesNotThrow(() -> mapper.toAccountEntity(accountRequestDto));
   }
@@ -65,11 +65,11 @@ public class AccountEntityMapperTest {
     var expectedPhoneNumber = "0700000000";
 
     var accountRequestDto = CreateAccountRequestDtoBuilder.builder()
-      .personalIdentityNumber(expectedPersonalIdentityNumber)
-      .emailAdress(expectedEmail)
-      .telephoneNumber(Optional.of(expectedPhoneNumber))
-      .publicKey(PublicKeyDtoBuilder.builder().build())
-      .build();
+        .personalIdentityNumber(Optional.of(expectedPersonalIdentityNumber))
+        .emailAdress(Optional.of(expectedEmail))
+        .telephoneNumber(Optional.of(expectedPhoneNumber))
+        .publicKey(PublicKeyDtoBuilder.builder().build())
+        .build();
 
     var accountEntity = mapper.toAccountEntity(accountRequestDto);
 
@@ -84,8 +84,8 @@ public class AccountEntityMapperTest {
     var expectedKeyId = randomId();
 
     var accountRequestDto = CreateAccountRequestDtoBuilder.builder()
-      .publicKey(TestUtils.publicKeyDtoBuilderWithDefaults(expectedKeyId).build())
-      .build();
+        .publicKey(TestUtils.publicKeyDtoBuilderWithDefaults(expectedKeyId).build())
+        .build();
 
     var accountEntity = mapper.toAccountEntity(accountRequestDto);
 
@@ -133,12 +133,12 @@ public class AccountEntityMapperTest {
     var expectedPhoneNumber = "0700000000";
 
     var accountEntity = new AccountEntity(
-      expectedPersonalIdentityNumber,
-      expectedEmail,
-      expectedPhoneNumber,
-      null,
-      new PublicKeyEntity(),
-      new PublicKeyEntity());
+        expectedPersonalIdentityNumber,
+        expectedEmail,
+        expectedPhoneNumber,
+        null,
+        new PublicKeyEntity(),
+        new PublicKeyEntity());
 
     var extendedAccountDto = mapper.toExtendedAccountDto(accountEntity);
 
@@ -152,12 +152,12 @@ public class AccountEntityMapperTest {
   void assertThatToExtendedAccountEntity_nullDeviceKey_throwsException() {
 
     var accountEntity = new AccountEntity(
-      null,
-      null,
-      null,
-      null,
-      new PublicKeyEntity(),
-      null);
+        null,
+        null,
+        null,
+        null,
+        new PublicKeyEntity(),
+        null);
 
     assertThrows(Exception.class, () -> mapper.toExtendedAccountDto(accountEntity));
   }
@@ -166,12 +166,12 @@ public class AccountEntityMapperTest {
   void assertThatToExtendedAccountEntity_nullWalletKey_throwsException() {
 
     var accountEntity = new AccountEntity(
-      null,
-      null,
-      null,
-      null,
-      null,
-      new PublicKeyEntity());
+        null,
+        null,
+        null,
+        null,
+        null,
+        new PublicKeyEntity());
 
 
     assertThrows(Exception.class, () -> mapper.toExtendedAccountDto(accountEntity));
@@ -182,21 +182,20 @@ public class AccountEntityMapperTest {
 
     var expectedKeyId = randomId();
     var publicKeyEntity = new PublicKeyEntity(
-      randomId(),
-      expectedKeyId,
-      randomId(),
-      randomId(),
-      randomId(),
-      randomId(),
-      randomId()
-    );
+        randomId(),
+        expectedKeyId,
+        randomId(),
+        randomId(),
+        randomId(),
+        randomId(),
+        randomId());
     var accountEntity = new AccountEntity(
-      null,
-      null,
-      null,
-      null,
-      new PublicKeyEntity(),
-      publicKeyEntity);
+        null,
+        null,
+        null,
+        null,
+        new PublicKeyEntity(),
+        publicKeyEntity);
 
     var extendedAccountDto = mapper.toExtendedAccountDto(accountEntity);
     var actualKey = extendedAccountDto.deviceKey();
@@ -217,21 +216,20 @@ public class AccountEntityMapperTest {
 
     var expectedKeyId = randomId();
     var publicKeyEntity = new PublicKeyEntity(
-      randomId(),
-      expectedKeyId,
-      randomId(),
-      randomId(),
-      randomId(),
-      randomId(),
-      randomId()
-    );
+        randomId(),
+        expectedKeyId,
+        randomId(),
+        randomId(),
+        randomId(),
+        randomId(),
+        randomId());
     var accountEntity = new AccountEntity(
-      null,
-      null,
-      null,
-      null,
-      publicKeyEntity,
-      new PublicKeyEntity());
+        null,
+        null,
+        null,
+        null,
+        publicKeyEntity,
+        new PublicKeyEntity());
 
     var extendedAccountDto = mapper.toExtendedAccountDto(accountEntity);
     var actualKey = extendedAccountDto.walletKey();
@@ -248,19 +246,20 @@ public class AccountEntityMapperTest {
   }
 
   @Test
-  void assertThatToExtendedAccountEntity_securityEnvelopeContent_containsMappedEqualContent() throws Exception {
+  void assertThatToExtendedAccountEntity_securityEnvelopeContent_containsMappedEqualContent()
+      throws Exception {
 
     var expectedContent = randomId();
     byte[] bytes = expectedContent.getBytes(StandardCharsets.UTF_8);
     var blob = new SerialBlob(bytes);
 
     var accountEntity = new AccountEntity(
-      null,
-      null,
-      null,
-      blob,
-      new PublicKeyEntity(),
-      new PublicKeyEntity());
+        null,
+        null,
+        null,
+        blob,
+        new PublicKeyEntity(),
+        new PublicKeyEntity());
 
     var extendedAccountDto = mapper.toExtendedAccountDto(accountEntity);
     var actualContent = extendedAccountDto.securityEnvelope();
@@ -288,13 +287,12 @@ public class AccountEntityMapperTest {
   void assertThatToAccountDto_emptyPersonalValues_shouldNotThrow() {
 
     var accountEntity = new AccountEntity(
-      null,
-      null,
-      null,
-      null,
-      new PublicKeyEntity(),
-      new PublicKeyEntity()
-    );
+        null,
+        null,
+        null,
+        null,
+        new PublicKeyEntity(),
+        new PublicKeyEntity());
 
     assertDoesNotThrow(() -> mapper.toAccountDto(accountEntity));
   }
@@ -307,13 +305,12 @@ public class AccountEntityMapperTest {
     var expectedPhoneNumber = "0700000000";
 
     var accountEntity = new AccountEntity(
-      expectedPersonalIdentityNumber,
-      expectedEmail,
-      expectedPhoneNumber,
-      null,
-      new PublicKeyEntity(),
-      new PublicKeyEntity()
-    );
+        expectedPersonalIdentityNumber,
+        expectedEmail,
+        expectedPhoneNumber,
+        null,
+        new PublicKeyEntity(),
+        new PublicKeyEntity());
 
     var mappedEntity = mapper.toAccountDto(accountEntity);
 
@@ -328,22 +325,20 @@ public class AccountEntityMapperTest {
 
     var expectedKeyId = randomId();
     var publicKeyEntity = new PublicKeyEntity(
-      randomId(),
-      expectedKeyId,
-      randomId(),
-      randomId(),
-      randomId(),
-      randomId(),
-      randomId()
-    );
+        randomId(),
+        expectedKeyId,
+        randomId(),
+        randomId(),
+        randomId(),
+        randomId(),
+        randomId());
     var accountEntity = new AccountEntity(
-      null,
-      null,
-      null,
-      null,
-      new PublicKeyEntity(),
-      publicKeyEntity
-    );
+        null,
+        null,
+        null,
+        null,
+        new PublicKeyEntity(),
+        publicKeyEntity);
 
     var mappedEntity = mapper.toAccountDto(accountEntity);
 

--- a/src/test/java/se/digg/wallet/account/infrastructure/mapper/AccountEntityMapperTest.java
+++ b/src/test/java/se/digg/wallet/account/infrastructure/mapper/AccountEntityMapperTest.java
@@ -142,8 +142,9 @@ public class AccountEntityMapperTest {
 
     var extendedAccountDto = mapper.toExtendedAccountDto(accountEntity);
 
-    assertEquals(expectedPersonalIdentityNumber, extendedAccountDto.personalIdentityNumber());
-    assertEquals(expectedEmail, extendedAccountDto.emailAdress());
+    assertEquals(expectedPersonalIdentityNumber,
+        extendedAccountDto.personalIdentityNumber().orElseThrow());
+    assertEquals(expectedEmail, extendedAccountDto.emailAdress().orElseThrow());
     assertThat(extendedAccountDto.telephoneNumber()).isPresent();
     assertEquals(expectedPhoneNumber, extendedAccountDto.telephoneNumber().get());
   }
@@ -314,8 +315,9 @@ public class AccountEntityMapperTest {
 
     var mappedEntity = mapper.toAccountDto(accountEntity);
 
-    assertEquals(expectedPersonalIdentityNumber, mappedEntity.personalIdentityNumber());
-    assertEquals(expectedEmail, mappedEntity.emailAdress());
+    assertEquals(expectedPersonalIdentityNumber,
+        mappedEntity.personalIdentityNumber().orElseThrow());
+    assertEquals(expectedEmail, mappedEntity.emailAdress().orElseThrow());
     assertThat(mappedEntity.telephoneNumber()).isPresent();
     assertEquals(expectedPhoneNumber, mappedEntity.telephoneNumber().get());
   }

--- a/src/test/java/se/digg/wallet/account/infrastructure/repository/AccountRepositoryTest.java
+++ b/src/test/java/se/digg/wallet/account/infrastructure/repository/AccountRepositoryTest.java
@@ -37,13 +37,14 @@ class AccountRepositoryTest {
   @Autowired
   TestEntityManager entityManager;
 
+  final String SECURITY_ENVELOPE = "this is just a String";
+  final String PERSONAL_IDENTITY_NUMBER = "770101-1234";
+  final String EMAIL = "none@business.se";
+  final String PHONE = "070-123 123 123";
+
   @Test
   void testSaveAndRetrieveAccount() throws SQLException {
-    final String securityEnvelope = "this is just a String";
-    final Blob securityEnvelopeBlob = BlobMapper.stringToBlob(securityEnvelope);
-    final String personalIdentityNumber = "770101-1234";
-    final String email = "none@business.se";
-    final String phone = "070-123 123 123";
+    final Blob securityEnvelopeBlob = BlobMapper.stringToBlob(SECURITY_ENVELOPE);
 
     AccountEntity entity =
         new AccountEntity(null,
@@ -53,15 +54,15 @@ class AccountRepositoryTest {
             TestUtils.generateJwkEntity(null),
             TestUtils.generateJwkEntity(UUID.randomUUID().toString()));
 
-    entity.setPersonalIdentityNumber(personalIdentityNumber);
-    entity.setPhone(phone);
-    entity.setEmail(email);
+    entity.setPersonalIdentityNumber(PERSONAL_IDENTITY_NUMBER);
+    entity.setPhone(PHONE);
+    entity.setEmail(EMAIL);
 
     AccountEntity storedEntity = accountRepository.save(entity);
     entityManager.flush();
     entityManager.clear();
 
-    AccountEntity foundEntity = accountRepository.findById(storedEntity.getId()).get();
+    AccountEntity foundEntity = accountRepository.findById(storedEntity.getId()).orElseThrow();
 
     assertThat(foundEntity)
         .isNotNull();
@@ -69,7 +70,7 @@ class AccountRepositoryTest {
     assertThat(foundEntity.getSecurityEnvelope())
         .isNotNull();
     assertThat(
-        BlobMapper.blobToString(foundEntity.getSecurityEnvelope()).equals(securityEnvelope));
+        BlobMapper.blobToString(foundEntity.getSecurityEnvelope()).equals(SECURITY_ENVELOPE));
     assertThat(foundEntity.getWalletKey())
         .isNotNull();
     assertThat(foundEntity.getWalletKey().getId()).isNotNull();
@@ -77,8 +78,33 @@ class AccountRepositoryTest {
         .isNotNull();
     assertThat(foundEntity.getDeviceKey().getId()).isNotNull();
 
-    assertThat(foundEntity.getPersonalIdentityNumber()).isEqualTo(personalIdentityNumber);
-    assertThat(foundEntity.getEmail()).isEqualTo(email);
-    assertThat(foundEntity.getPhone()).isEqualTo(phone);
+    assertThat(foundEntity.getPersonalIdentityNumber()).isEqualTo(PERSONAL_IDENTITY_NUMBER);
+    assertThat(foundEntity.getEmail()).isEqualTo(EMAIL);
+    assertThat(foundEntity.getPhone()).isEqualTo(PHONE);
+  }
+
+  @Test
+  void saveAndRetrieveAccountShouldHandleNullPersonalIdentityNumber() throws SQLException {
+    final Blob securityEnvelopeBlob = BlobMapper.stringToBlob(SECURITY_ENVELOPE);
+
+    AccountEntity entity =
+        new AccountEntity(null,
+            EMAIL,
+            PHONE,
+            securityEnvelopeBlob,
+            TestUtils.generateJwkEntity(null),
+            TestUtils.generateJwkEntity(UUID.randomUUID().toString()));
+
+    AccountEntity storedEntity = accountRepository.save(entity);
+    entityManager.flush();
+    entityManager.clear();
+
+    AccountEntity foundEntity = accountRepository.findById(storedEntity.getId()).orElseThrow();
+
+    assertThat(foundEntity)
+        .isNotNull();
+    // .isEqualTo(storedEntity);
+
+    assertThat(foundEntity.getPersonalIdentityNumber()).isNull();
   }
 }

--- a/src/test/java/se/digg/wallet/account/infrastructure/repository/AccountRepositoryTest.java
+++ b/src/test/java/se/digg/wallet/account/infrastructure/repository/AccountRepositoryTest.java
@@ -37,10 +37,10 @@ class AccountRepositoryTest {
   @Autowired
   TestEntityManager entityManager;
 
-  final String SECURITY_ENVELOPE = "this is just a String";
-  final String PERSONAL_IDENTITY_NUMBER = "770101-1234";
-  final String EMAIL = "none@business.se";
-  final String PHONE = "070-123 123 123";
+  private final String SECURITY_ENVELOPE = "this is just a String";
+  private final String PERSONAL_IDENTITY_NUMBER = "770101-1234";
+  private final String EMAIL = "none@business.se";
+  private final String PHONE = "070-123 123 123";
 
   @Test
   void testSaveAndRetrieveAccount() throws SQLException {


### PR DESCRIPTION
# Pull Request Description

When creating a wallet account, the parameters for email and personal identity number are now optional.

```
--                            What's Changed                            --
--------------------------------------------------------------------------
- POST   /v0/accounts
  Request:
        - Changed application/json
          Schema: Backward compatible
  Return Type:
    - Changed 201 Created
      Media types:
        - Changed application/json
          Schema: Broken compatibility
- GET    /v0/accounts/{id}
  Return Type:
    - Changed 200 OK
      Media types:
        - Changed application/json
          Schema: Broken compatibility
--------------------------------------------------------------------------
--                                Result                                --
--------------------------------------------------------------------------
                 API changes broke backward compatibility     

```
Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
