### PR TITLE
feat: add HSM client id endpoints for accounts

### DIFF
--- a/src/main/java/se/digg/wallet/account/application/controller/AccountV0Controller.java
+++ b/src/main/java/se/digg/wallet/account/application/controller/AccountV0Controller.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 import se.digg.wallet.account.api.v0.AccountApi;
 import se.digg.wallet.account.api.v0.model.AccountRequest;
 import se.digg.wallet.account.api.v0.model.AccountResponse;
+import se.digg.wallet.account.api.v0.model.HsmClientIdRequest;
+import se.digg.wallet.account.api.v0.model.HsmClientIdResponse;
 import se.digg.wallet.account.api.v0.model.KeyRequest;
 import se.digg.wallet.account.api.v0.model.KeyResponse;
 import se.digg.wallet.account.api.v0.model.KeysResponse;
@@ -132,6 +134,36 @@ public class AccountV0Controller implements AccountApi {
     return ResponseEntity.ok(securityEnvelopesResponse);
   }
 
+  @Override
+  public ResponseEntity<HsmClientIdResponse> addAccountHsmClientId(UUID id,
+      HsmClientIdRequest hsmClientIdRequest) {
+
+    var accountDto = accountService.getAccountById(id);
+    if (accountDto.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+
+    var savedHsmClientId = accountService.createHsmClientId(id, hsmClientIdRequest.getClientId());
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(toHsmClientIdResponse(savedHsmClientId));
+  }
+
+  @Override
+  public ResponseEntity<HsmClientIdResponse> getAccountHsmClientId(UUID id) {
+
+    var accountDto = accountService.getAccountById(id);
+    if (accountDto.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+
+    return accountService.getHsmClientId(id)
+        .map(AccountV0Controller::toHsmClientIdResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
   private static CreateAccountRequestDto toCreateAccountDto(
       AccountRequest accountRequest) {
 
@@ -199,6 +231,12 @@ public class AccountV0Controller implements AccountApi {
   private static SecurityEnvelopeResponse toSecurityEnvelopeResponse(String content) {
     return SecurityEnvelopeResponse.builder()
         .content(content)
+        .build();
+  }
+
+  private static HsmClientIdResponse toHsmClientIdResponse(String clientId) {
+    return HsmClientIdResponse.builder()
+        .clientId(clientId)
         .build();
   }
 }

--- a/src/main/java/se/digg/wallet/account/domain/service/AccountService.java
+++ b/src/main/java/se/digg/wallet/account/domain/service/AccountService.java
@@ -70,6 +70,18 @@ public class AccountService {
     return Optional.ofNullable(toPublicKeyDto(entity.getWalletKey()));
   }
 
+  public String createHsmClientId(UUID accountId, String hsmClientId) {
+    AccountEntity entity = accountRepository.findById(accountId).orElseThrow();
+    entity.setHsmClientId(hsmClientId);
+    var savedEntity = accountRepository.save(entity);
+    return savedEntity.getHsmClientId();
+  }
+
+  public Optional<String> getHsmClientId(UUID accountId) {
+    AccountEntity entity = accountRepository.findById(accountId).orElseThrow();
+    return Optional.ofNullable(entity.getHsmClientId());
+  }
+
   public String createSecurityEnvelope(UUID accountId, String securityEnvelope) {
     try {
       AccountEntity entity = accountRepository.findById(accountId).orElseThrow();

--- a/src/main/java/se/digg/wallet/account/infrastructure/model/AccountEntity.java
+++ b/src/main/java/se/digg/wallet/account/infrastructure/model/AccountEntity.java
@@ -33,6 +33,9 @@ public class AccountEntity {
   @Column
   private String phone;
 
+  @Column
+  private String hsmClientId;
+
   @JdbcTypeCode(SqlTypes.BLOB)
   @Column(columnDefinition = "blob")
   private Blob securityEnvelope;
@@ -91,6 +94,14 @@ public class AccountEntity {
     this.phone = phone;
   }
 
+  public String getHsmClientId() {
+    return hsmClientId;
+  }
+
+  public void setHsmClientId(String hsmClientId) {
+    this.hsmClientId = hsmClientId;
+  }
+
   public Blob getSecurityEnvelope() {
     return securityEnvelope;
   }
@@ -117,7 +128,7 @@ public class AccountEntity {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, email, phone, securityEnvelope, walletKey, deviceKey);
+    return Objects.hash(id, email, phone, hsmClientId, securityEnvelope, walletKey, deviceKey);
   }
 
   @Override
@@ -137,6 +148,7 @@ public class AccountEntity {
     return Objects.equals(id, other.id)
         && Objects.equals(email, other.email)
         && Objects.equals(phone, other.phone)
+        && Objects.equals(hsmClientId, other.hsmClientId)
         && Objects.equals(securityEnvelope, other.securityEnvelope)
         && Objects.equals(walletKey, other.walletKey)
         && Objects.equals(other.deviceKey, deviceKey);
@@ -146,6 +158,7 @@ public class AccountEntity {
   public String toString() {
     return "AccountEntity [id=" + id + ", personalIdentityNumber=" + personalIdentityNumber
         + ", email=" + email + ", phone=" + phone
+        + ", hsmClientId=" + hsmClientId
         + ", securityEnvelope=" + securityEnvelope + ", walletKey=" + walletKey
         + ", deviceKey=" + deviceKey + "]";
   }

--- a/src/main/resources/db/changelog/changelog.yml
+++ b/src/main/resources/db/changelog/changelog.yml
@@ -118,3 +118,13 @@ databaseChangeLog:
         - dropNotNullConstraint:
             tableName: accounts
             columnName: personal_identity_number
+  - changeSet:
+      id: 20260623-0
+      author: Asser Hakala
+      changes:
+        - addColumn:
+            tableName: accounts
+            columns:
+              - column:
+                  name: hsm_client_id
+                  type: VARCHAR(255)

--- a/src/main/resources/static/wallet-account-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-account-openapi-v0.yaml
@@ -196,6 +196,51 @@ paths:
         'default':
           $ref: '#/components/responses/default'
 
+  /v0/accounts/{id}/hsm-client-id:
+    post:
+      tags:
+        - Account
+      summary: Set the HSM client id for an account
+      description: Stores the HSM client identifier for the account.
+      operationId: addAccountHsmClientId
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HsmClientIdRequest'
+        required: true
+      responses:
+        '201':
+          description: HSM client id stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HsmClientIdResponse'
+        'default':
+          $ref: '#/components/responses/default'
+
+    get:
+      tags:
+        - Account
+      summary: Get the HSM client id for an account
+      description: Get the HSM client identifier stored for a given account.
+      operationId: getAccountHsmClientId
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      responses:
+        '200':
+          description: The HSM client id being returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HsmClientIdResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        'default':
+          $ref: '#/components/responses/default'
+
 components:
   parameters:
     AccountId:
@@ -439,3 +484,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SecurityEnvelopeResponse'
+
+    HsmClientIdRequest:
+      type: object
+      properties:
+        clientId:
+          type: string
+          minLength: 1
+          description: HSM client identifier, minted at device-state registration.
+          example: 'b9f6edba-b69d-4e56-be22-dae25a45ff91'
+      required:
+        - clientId
+
+    HsmClientIdResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/HsmClientIdRequest'

--- a/src/test/java/se/digg/wallet/account/application/controller/AccountV0ControllerTest.java
+++ b/src/test/java/se/digg/wallet/account/application/controller/AccountV0ControllerTest.java
@@ -26,6 +26,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import se.digg.wallet.account.TestUtils;
 import se.digg.wallet.account.api.v0.model.AccountRequest;
 import se.digg.wallet.account.api.v0.model.AccountResponse;
+import se.digg.wallet.account.api.v0.model.HsmClientIdRequest;
+import se.digg.wallet.account.api.v0.model.HsmClientIdResponse;
 import se.digg.wallet.account.api.v0.model.KeyRequest;
 import se.digg.wallet.account.api.v0.model.KeysResponse;
 import se.digg.wallet.account.api.v0.model.SecurityEnvelopeRequest;
@@ -442,6 +444,121 @@ public class AccountV0ControllerTest {
     var actualSecurityEnvelope = actualItems.getFirst();
     var actualContent = actualSecurityEnvelope.getContent();
     assertThat(actualContent).isEqualTo(expectedContent);
+  }
+
+  @Test
+  void assertThatAddHsmClientId_usingNonExistingAccount_returnsNotFound() throws Exception {
+
+    when(accountService.getAccountById(any(UUID.class))).thenReturn(Optional.empty());
+
+    var hsmClientIdRequest = HsmClientIdRequest.builder()
+        .clientId(randomId())
+        .build();
+
+    mockMvc
+        .perform(post("/v0/accounts/{0}/hsm-client-id", UUID.randomUUID())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(hsmClientIdRequest)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void assertThatAddHsmClientId_withNullClientId_returnsBadRequest() throws Exception {
+
+    var hsmClientIdRequest = HsmClientIdRequest.builder()
+        .clientId(null)
+        .build();
+
+    mockMvc
+        .perform(post("/v0/accounts/{0}/hsm-client-id", UUID.randomUUID())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(hsmClientIdRequest)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void assertThatAddHsmClientId_withAcceptableRequest_returnsCreated() throws Exception {
+
+    var expectedClientId = randomId();
+    var existingAccount = AccountDtoBuilder.builder()
+        .id(UUID.randomUUID())
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
+        .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
+        .build();
+
+    when(accountService.getAccountById(any(UUID.class))).thenReturn(Optional.of(existingAccount));
+    when(accountService.createHsmClientId(any(), any())).thenReturn(expectedClientId);
+
+    var hsmClientIdRequest = HsmClientIdRequest.builder()
+        .clientId(expectedClientId)
+        .build();
+
+    var result = mockMvc
+        .perform(post("/v0/accounts/{0}/hsm-client-id", UUID.randomUUID())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(hsmClientIdRequest)))
+        .andExpect(status().isCreated())
+        .andReturn();
+    var hsmClientIdResponse = objectMapper
+        .readValue(result.getResponse().getContentAsString(), HsmClientIdResponse.class);
+
+    assertThat(hsmClientIdResponse.getClientId()).isEqualTo(expectedClientId);
+  }
+
+  @Test
+  void assertThatGetHsmClientId_usingNonExistingAccount_returnsNotFound() throws Exception {
+
+    when(accountService.getAccountById(any(UUID.class))).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(get("/v0/accounts/{0}/hsm-client-id", UUID.randomUUID()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void assertThatGetHsmClientId_existingAccountWithoutHsmClientId_returnsNotFound()
+      throws Exception {
+
+    var existingAccount = AccountDtoBuilder.builder()
+        .id(UUID.randomUUID())
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
+        .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
+        .build();
+
+    when(accountService.getAccountById(any(UUID.class))).thenReturn(Optional.of(existingAccount));
+    when(accountService.getHsmClientId(any(UUID.class))).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(get("/v0/accounts/{0}/hsm-client-id", UUID.randomUUID()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void assertThatGetHsmClientId_existingAccountWithHsmClientId_returnsExpectedClientId()
+      throws Exception {
+
+    var expectedClientId = randomId();
+    var existingAccount = AccountDtoBuilder.builder()
+        .id(UUID.randomUUID())
+        .emailAdress(Optional.of(EMAIL))
+        .personalIdentityNumber(Optional.of(PERSONAL_IDENTITY_NUMBER))
+        .publicKey(publicKeyDtoBuilderWithDefaults(randomId()).build())
+        .build();
+
+    when(accountService.getAccountById(any(UUID.class))).thenReturn(Optional.of(existingAccount));
+    when(accountService.getHsmClientId(any(UUID.class)))
+        .thenReturn(Optional.of(expectedClientId));
+
+    var result = mockMvc
+        .perform(get("/v0/accounts/{0}/hsm-client-id", UUID.randomUUID()))
+        .andExpect(status().isOk())
+        .andReturn();
+    var hsmClientIdResponse = objectMapper
+        .readValue(result.getResponse().getContentAsString(), HsmClientIdResponse.class);
+
+    assertThat(hsmClientIdResponse.getClientId()).isEqualTo(expectedClientId);
   }
 
   private static String randomId() {

--- a/src/test/java/se/digg/wallet/account/application/service/AccountServiceTest.java
+++ b/src/test/java/se/digg/wallet/account/application/service/AccountServiceTest.java
@@ -361,6 +361,78 @@ class AccountServiceTest {
     assertThat(actualContent.get()).isEqualTo(expectedContent);
   }
 
+  @Test
+  void assertThatCreateHsmClientId_nonExistingAccount_throwsNoSuchElementException() {
+
+    when(accountRepository.findById(any())).thenReturn(Optional.empty());
+
+    assertThrows(NoSuchElementException.class,
+        () -> accountService.createHsmClientId(UUID.randomUUID(), randomId()));
+  }
+
+  @Test
+  void assertThatCreateHsmClientId_addNewClientId_shouldReturnCreatedClientId() {
+
+    var expectedClientId = randomId();
+    var existingAccountEntity = new AccountEntity();
+
+    when(accountRepository.findById(any())).thenReturn(Optional.of(existingAccountEntity));
+    when(accountRepository.save(eq(existingAccountEntity))).thenReturn(existingAccountEntity);
+
+    var actualClientId = accountService.createHsmClientId(UUID.randomUUID(), expectedClientId);
+
+    assertThat(actualClientId).isEqualTo(expectedClientId);
+  }
+
+  @Test
+  void assertThatCreateHsmClientId_replaceExistingClientId_shouldReturnReplacedClientId() {
+
+    var expectedClientId = randomId();
+    var existingAccountEntity = new AccountEntity();
+    existingAccountEntity.setHsmClientId(randomId());
+
+    when(accountRepository.findById(any())).thenReturn(Optional.of(existingAccountEntity));
+    when(accountRepository.save(eq(existingAccountEntity))).thenReturn(existingAccountEntity);
+
+    var actualClientId = accountService.createHsmClientId(UUID.randomUUID(), expectedClientId);
+
+    assertThat(actualClientId).isEqualTo(expectedClientId);
+  }
+
+  @Test
+  void assertThatGetHsmClientId_nonExistingAccount_throwsNoSuchElementException() {
+
+    when(accountRepository.findById(any())).thenReturn(Optional.empty());
+
+    assertThrows(NoSuchElementException.class,
+        () -> accountService.getHsmClientId(UUID.randomUUID()));
+  }
+
+  @Test
+  void assertThatGetHsmClientId_existingAccountWithoutHsmClientId_shouldReturnEmpty() {
+
+    var existingAccountEntity = new AccountEntity();
+
+    when(accountRepository.findById(any())).thenReturn(Optional.of(existingAccountEntity));
+
+    var actualClientId = accountService.getHsmClientId(UUID.randomUUID());
+    assertThat(actualClientId).isEmpty();
+  }
+
+  @Test
+  void assertThatGetHsmClientId_existingAccountWithHsmClientId_shouldReturnExpectedClientId() {
+
+    var expectedClientId = randomId();
+    var existingAccountEntity = new AccountEntity();
+    existingAccountEntity.setHsmClientId(expectedClientId);
+
+    when(accountRepository.findById(any())).thenReturn(Optional.of(existingAccountEntity));
+
+    var actualClientId = accountService.getHsmClientId(UUID.randomUUID());
+    assertThat(actualClientId).isPresent();
+    assertThat(actualClientId.get()).isEqualTo(expectedClientId);
+  }
+
   private static String randomId() {
     return UUID.randomUUID().toString();
   }


### PR DESCRIPTION
* feat: add POST and GET /v0/accounts/{id}/hsm-client-id endpoints
* feat: store hsm_client_id on account entity with liquibase changeset
* test: cover HSM client id controller and service behaviour

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
